### PR TITLE
django 2.2.11 fix

### DIFF
--- a/src/shorturls/urls.py
+++ b/src/shorturls/urls.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from . import views
 
 
-def handler404(req):
+def handler404(req, exception):
     return HttpResponse(status=404)
 
 


### PR DESCRIPTION
Added new argument to handler404 function as required by django 2.2.11. Mistakenly named the commit 'django 2.2.15 fix' when it actually should be '2.2.11'.